### PR TITLE
Change GenericSmelters to GenericCrafters

### DIFF
--- a/content/blocks/aluminum-forge.hjson
+++ b/content/blocks/aluminum-forge.hjson
@@ -1,7 +1,7 @@
 {
 	"name": "Aluminum Forge",
 	"description": "Uses massive amounts of electricity to smelt aluminum ore into aluminum.",
-	"type": "GenericSmelter",
+	"type": "GenericCrafter",
 	"outputItem": {"item": "aluminum", "amount": "1"},
 	"consumes": {
 		"power": 3.0,

--- a/content/blocks/heavy-oil-burner.hjson
+++ b/content/blocks/heavy-oil-burner.hjson
@@ -1,7 +1,7 @@
 {
 	"name": "Heavy Oil Burner",
 	"description": "Burns off excess heavy oil created from oil distillation.",
-	"type": "GenericSmelter",
+	"type": "GenericCrafter",
 	"consumes": {
 		"power": 1.0,
 		"liquid": {"liquid": "heavy-oil", "amount": 0.25}

--- a/content/blocks/light-oil-burner.hjson
+++ b/content/blocks/light-oil-burner.hjson
@@ -1,7 +1,7 @@
 {
 	"name": "Light Oil Burner",
 	"description": "Burns off excess light oil created from oil distillation.",
-	"type": "GenericSmelter",
+	"type": "GenericCrafter",
 	"consumes": {
 		"power": 1.0,
 		"liquid": {"liquid": "light-oil", "amount": 0.25}

--- a/content/blocks/sludge-burner.hjson
+++ b/content/blocks/sludge-burner.hjson
@@ -1,7 +1,7 @@
 {
 	"name": "Sludge Burner",
 	"description": "Burns off excess sludge created from oil distillation.",
-	"type": "GenericSmelter",
+	"type": "GenericCrafter",
 	"consumes": {
 		"power": 1.0,
 		"items": {

--- a/content/blocks/steel-forge.hjson
+++ b/content/blocks/steel-forge.hjson
@@ -1,7 +1,7 @@
 {
 	"name": "Steel Forge",
 	"description": "Creates steel from iron and coal.",
-	"type": "GenericSmelter",
+	"type": "GenericCrafter",
 	"outputItem": {"item": "steel", "amount": "2"},
 	"consumes": {
 		"power": 0.75,

--- a/content/blocks/titanium-forge.hjson
+++ b/content/blocks/titanium-forge.hjson
@@ -1,7 +1,7 @@
 {
 	"name": "Titanium Forge",
 	"description": "Creates titanium from lead and graphite.",
-	"type": "GenericSmelter",
+	"type": "GenericCrafter",
 	"outputItem": {"item": "titanium", "amount": "1"},
 	"consumes": {
 		"power": 0.75,


### PR DESCRIPTION
For some reason, in the latest version, `GenericSmelter`s appear to be broken (can't be interacted with in any way)

Changed all the `GenericSmelter`s to `GenericCrafter`s because this appears to have no consequences and fixed the issue

I don't really know anything about mindustry modding so if theres an issue here with blanket converting to `GenericCrafter` do correct me

(The block broken in this clip is the Aluminum forge)
https://github.com/What42Pizza/Mindustry-Production-Mod/assets/49820045/57d4e9f6-3a7b-4af6-828d-b7d59aee1f63

